### PR TITLE
Shortcut correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Use the following to embed a beautify shortcut in keybindings.json. Replace with
 
 ```json
     {
-      "key": "ctrl+shift+f",          
-      "command": "extension.vueBeautify",
+      "key": "alt+shift+f",          
+      "command": "vueBeautify.format",
       "when": "editorTextFocus && !editorReadonly" 
     }
 ```


### PR DESCRIPTION
For me (running on MacOS), the shortcut you proposed is already taken (it opens the search panel), and extension.vueBeautify doesn't work. Maybe just a problem of i18n, hope it helped. 
Cool extension, thank you.