### PR TITLE
Move default mac shortcut to cmd + shift + v, because cmd + shift + f…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
             {
                 "command": "vueBeautify.format",
                 "key": "ctrl+shift+f",
-                "mac": "cmd+shift+f",
+                "mac": "cmd+shift+v",
                 "linux": "ctrl+shift+f",
                 "when": "resourceLangId=='vue' && editorTextFocus && editorTextFocus && !editorReadonly"
             }


### PR DESCRIPTION
… is already the built in search function

fixes #26 